### PR TITLE
Make it possible to bump container base image with renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "config:recommended",
     "github>kachick/renovate-config-dprint#1.3.0",
     "github>kachick/renovate-config-dprint:self"
   ],

--- a/images/ubuntu-nix-sudoer/Containerfile
+++ b/images/ubuntu-nix-sudoer/Containerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses=MIT
 # --no-install-recommends omits ca-certificates
 # sudo is required in non systemd with Nix
 RUN apt-get update \
- && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.1	ca-certificates=20240203 \
+ && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.4	ca-certificates=20240203 \
  sudo=1.9.15p5-3ubuntu5 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/images/ubuntu-nix-sudoer/Containerfile
+++ b/images/ubuntu-nix-sudoer/Containerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:noble-20240801
 
 LABEL org.opencontainers.image.source=https://github.com/kachick/containers
 LABEL org.opencontainers.image.description="Nix package manager on Ubuntu - sudoer"

--- a/images/ubuntu-nix-systemd/Containerfile
+++ b/images/ubuntu-nix-systemd/Containerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:noble-20240801
 
 LABEL org.opencontainers.image.source=https://github.com/kachick/containers
 LABEL org.opencontainers.image.description="Nix package manager on Ubuntu - systemd"

--- a/images/ubuntu-nix-systemd/Containerfile
+++ b/images/ubuntu-nix-systemd/Containerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses=MIT
 # --no-install-recommends omits ca-certificates
 RUN apt-get update \
  && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.4	ca-certificates=20240203 \
- systemd=255.4-1ubuntu8 \
+ systemd=255.4-1ubuntu8.4 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 

--- a/images/ubuntu-nix-systemd/Containerfile
+++ b/images/ubuntu-nix-systemd/Containerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.licenses=MIT
 # Available versions in apt: https://packages.ubuntu.com/noble/curl
 # --no-install-recommends omits ca-certificates
 RUN apt-get update \
- && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.1	ca-certificates=20240203 \
+ && apt-get install --no-install-recommends -y curl=8.5.0-2ubuntu10.4	ca-certificates=20240203 \
  systemd=255.4-1ubuntu8 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- **Enable dashboard and docker manager in renovatebot**
- **Intentionally specify old version of docker image to test**

Resolves GH-137
